### PR TITLE
fix: 온보딩 시 funnel, job이 null을 허용 하도록 변경

### DIFF
--- a/api/src/main/java/vook/server/api/domain/user/service/data/OnboardingCommand.java
+++ b/api/src/main/java/vook/server/api/domain/user/service/data/OnboardingCommand.java
@@ -1,7 +1,6 @@
 package vook.server.api.domain.user.service.data;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import vook.server.api.domain.user.model.Funnel;
 import vook.server.api.domain.user.model.Job;
@@ -11,10 +10,7 @@ public record OnboardingCommand(
         @NotBlank
         String userUid,
 
-        @NotNull
         Funnel funnel,
-
-        @NotNull
         Job job
 ) {
 }

--- a/api/src/main/java/vook/server/api/web/user/UserApi.java
+++ b/api/src/main/java/vook/server/api/web/user/UserApi.java
@@ -70,6 +70,11 @@ public interface UserApi {
                     @SecurityRequirement(name = "AccessToken")
             },
             description = """
+                    ## 호출 시나리오
+                    - 회원가입이 완료된 유저가 온보딩 프로세스의 마지막 페이지에서 '시작하기' 버튼을 클릭했을 때 호출됩니다.
+                    - '건너뛰기' 버튼을 클릭 할 경우 해당 온보딩 프로세스 페이지의 선택 값을 null로 합니다.
+                    - 온보딩 프로세스의 마지막 페이지에서 '건너뛰기' 버튼을 클릭했을 때도 이 API를 호출합니다. 
+                                        
                     ## 비즈니스 규칙 위반 내용
                     - NotReadyToOnboarding: 회원 가입이 완료되지 않은 유저가 해당 API를 호출 할 경우
                     - AlreadyOnboarding: 이미 온보딩이 완료된 유저가 해당 API를 호출 할 경우"""

--- a/api/src/test/java/vook/server/api/domain/user/service/UserServiceTest.java
+++ b/api/src/test/java/vook/server/api/domain/user/service/UserServiceTest.java
@@ -320,14 +320,6 @@ class UserServiceTest extends IntegrationTestBase {
                 DynamicTest.dynamicTest("유저 UID가 빈 문자열인 경우", () -> {
                     assertThatThrownBy(() -> service.onboarding(new OnboardingCommand("", Funnel.OTHER, Job.OTHER)))
                             .isInstanceOf(ParameterValidateException.class);
-                }),
-                DynamicTest.dynamicTest("퍼널이 누락된 경우", () -> {
-                    assertThatThrownBy(() -> service.onboarding(new OnboardingCommand("uid", null, Job.OTHER)))
-                            .isInstanceOf(ParameterValidateException.class);
-                }),
-                DynamicTest.dynamicTest("직업이 누락된 경우", () -> {
-                    assertThatThrownBy(() -> service.onboarding(new OnboardingCommand("uid", Funnel.OTHER, null)))
-                            .isInstanceOf(ParameterValidateException.class);
                 })
         );
     }


### PR DESCRIPTION
# Overview

온보딩 시 funnel, job이 null을 허용 하도록 변경

# Issue

#109 

# Check List

- [x] 관련된 이슈를 연결하였나요?
- [x] 올바른 PR 컨벤션을 작성했나요?
- [x] 적절한 라벨을 선택했나요?
- [x] Assignee와 Reviewer를 설정했나요?
