### PR TITLE
bug: 용어 조회 시, 저장 된 모든 용어가 나오는 버그 대응

### DIFF
--- a/api/src/main/java/vook/server/api/infra/term/JpaTermSearchRepository.java
+++ b/api/src/main/java/vook/server/api/infra/term/JpaTermSearchRepository.java
@@ -21,20 +21,22 @@ public class JpaTermSearchRepository implements RetrieveTermUseCase.TermSearchSe
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Term> findAllBy(Pageable pageable) {
+    public Page<Term> findAllBy(String vocabularyUid, Pageable pageable) {
         QTerm term = QTerm.term1;
 
         JPAQuery<Term> dataQuery = queryFactory
                 .selectFrom(term)
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
+                .limit(pageable.getPageSize())
+                .where(term.vocabulary.uid.eq(vocabularyUid));
 
         QuerydslHelper.toOrderSpecifiers(term, pageable).forEach(dataQuery::orderBy);
         List<Term> result = dataQuery.fetch();
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(term.count())
-                .from(term);
+                .from(term)
+                .where(term.vocabulary.uid.eq(vocabularyUid));
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }

--- a/api/src/main/java/vook/server/api/usecases/term/RetrieveTermUseCase.java
+++ b/api/src/main/java/vook/server/api/usecases/term/RetrieveTermUseCase.java
@@ -30,7 +30,7 @@ public class RetrieveTermUseCase {
         Vocabulary vocabulary = vocabularyService.getByUid(command.vocabularyUid());
         vocabularyPolicy.validateOwner(user, vocabulary);
 
-        Page<Term> termPage = termSearchService.findAllBy(command.pageable());
+        Page<Term> termPage = termSearchService.findAllBy(command.vocabularyUid(), command.pageable());
         Page<Result.Tuple> tuplePage = termPage.map(Result.Tuple::from);
         return new Result(tuplePage);
     }
@@ -66,6 +66,6 @@ public class RetrieveTermUseCase {
     }
 
     public interface TermSearchService {
-        Page<Term> findAllBy(Pageable params);
+        Page<Term> findAllBy(String vocabularyUid, Pageable params);
     }
 }

--- a/api/src/test/java/vook/server/api/usecases/term/RetrieveTermUseCaseTest.java
+++ b/api/src/test/java/vook/server/api/usecases/term/RetrieveTermUseCaseTest.java
@@ -185,4 +185,31 @@ class RetrieveTermUseCaseTest extends IntegrationTestBase {
         );
     }
 
+    @Test
+    @DisplayName("용어 조회 - 정상; 2개 이상의 용어집에서 검색")
+    void executeMultipleVocabularies() {
+        // given
+        User user = testUserCreator.createCompletedOnboardingUser();
+        Vocabulary vocabulary1 = testVocabularyCreator.createVocabulary(user);
+        testVocabularyCreator.createTerm(vocabulary1);
+        Vocabulary vocabulary2 = testVocabularyCreator.createVocabulary(user);
+        Term term2 = testVocabularyCreator.createTerm(vocabulary2);
+
+        RetrieveTermUseCase.Command command = new RetrieveTermUseCase.Command(
+                user.getUid(),
+                vocabulary2.getUid(),
+                PageRequest.ofSize(Integer.MAX_VALUE)
+        );
+
+        // when
+        RetrieveTermUseCase.Result result = useCase.execute(command);
+
+        // then
+        assertThat(result.terms().getContent()).hasSize(1);
+        assertThat(result.terms().getContent().getFirst().termUid()).isEqualTo(term2.getUid());
+        assertThat(result.terms().getContent().getFirst().term()).isEqualTo(term2.getTerm());
+        assertThat(result.terms().getContent().getFirst().meaning()).isEqualTo(term2.getMeaning());
+        assertThat(result.terms().getContent().getFirst().synonyms()).containsExactlyInAnyOrderElementsOf(term2.getSynonyms());
+    }
+
 }


### PR DESCRIPTION
# Overview

용어 조회 시, 저장 된 모든 용어가 나오는 버그 대응

# Issue

#111 

# Check List

- [x] 관련된 이슈를 연결하였나요?
- [x] 올바른 PR 컨벤션을 작성했나요?
- [x] 적절한 라벨을 선택했나요?
- [x] Assignee와 Reviewer를 설정했나요?
